### PR TITLE
Implemented three previously unimplemented methods in ConfigMapPath

### DIFF
--- a/HttpSimulator/HttpSimulator.cs
+++ b/HttpSimulator/HttpSimulator.cs
@@ -750,17 +750,18 @@ namespace Http.TestLibrary
 
             public string GetMachineConfigFilename()
             {
-                throw new NotImplementedException();
+                return System.Runtime.InteropServices.RuntimeEnvironment.SystemConfigurationFile;
             }
 
             public string GetRootWebConfigFilename()
             {
-                throw new NotImplementedException();
+                return null;
             }
 
             public void GetPathConfigFilename(string siteID, string path, out string directory, out string baseName)
             {
-                throw new NotImplementedException();
+                directory = _requestSimulation.PhysicalApplicationPath;
+                baseName = "Web.config";
             }
 
             public void GetDefaultSiteNameAndID(out string siteName, out string siteID)


### PR DESCRIPTION
Implemented three previously unimplemented methods in ConfigMapPath to enhance support for testing applications that rely on Web.config (e.g. connectionStrings, custom config sections, etc.).

The NotImplementedExceptions were causing our simulations to fail.