### PR TITLE
Add fluent interface for IsLocal requests

### DIFF
--- a/HttpSimulator.Tests/Test.cs
+++ b/HttpSimulator.Tests/Test.cs
@@ -19,6 +19,27 @@ namespace HttpSimulatorTests
             }
         }
 
+        [Test]
+        public void RequestsAreLocalByDefault()
+        {
+            using (new HttpSimulator("/", @"c:\inetpub\").SimulateRequest())
+            {
+                Assert.IsTrue(HttpContext.Current.Request.IsLocal);
+            }
+        }
+
+        [Test]
+        public void CanSimulateRemoteRequests()
+        {
+            using (var simulator = new HttpSimulator())
+            {
+                simulator.SetIsLocalRequest(false)
+                    .SimulateRequest(new Uri("http://something.com/Test.aspx"), HttpVerb.GET);
+
+                Assert.IsFalse(HttpContext.Current.Request.IsLocal);
+            }
+        }
+
         /// <summary>
         /// Determines whether this instance [can get set session].
         /// </summary>

--- a/HttpSimulator/HttpSimulator.cs
+++ b/HttpSimulator/HttpSimulator.cs
@@ -33,6 +33,7 @@ namespace Http.TestLibrary
         private const string defaultPhysicalAppPath = @"c:\InetPub\wwwRoot\";
         private StringBuilder builder;
         private Uri _referer;
+        private bool _isLocalRequest = true;
         private NameValueCollection _formVars = new NameValueCollection();
         private NameValueCollection _headers = new NameValueCollection();
         private TextWriter debugWriter = Console.Out;
@@ -154,6 +155,8 @@ namespace Http.TestLibrary
 
             if (_referer != null)
                 this.workerRequest.SetReferer(_referer);
+
+            this.workerRequest.SetIsLocalRequest(_isLocalRequest);
 
             InitializeSession();
 
@@ -510,6 +513,19 @@ namespace Http.TestLibrary
             if (this.workerRequest != null)
                 this.workerRequest.SetReferer(referer);
             this._referer = referer;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether it is a request from the local machine. Uses a fluent interface.
+        /// </summary>
+        /// <param name="isLocalRequest"></param>
+        /// <returns></returns>
+        public HttpSimulator SetIsLocalRequest(bool isLocalRequest)
+        {
+            if (this.workerRequest != null)
+                this.workerRequest.SetIsLocalRequest(isLocalRequest);
+            this._isLocalRequest = isLocalRequest;
             return this;
         }
 

--- a/HttpSimulator/SimulatedHttpRequest.cs
+++ b/HttpSimulator/SimulatedHttpRequest.cs
@@ -17,6 +17,7 @@ namespace Http.TestLibrary
         string _verb;
         int _port;
         string _physicalFilePath;
+        bool _isLocalRequest;
 
         /// <summary>
         /// Creates a new <see cref="SimulatedHttpRequest"/> instance.
@@ -53,6 +54,11 @@ namespace Http.TestLibrary
         internal void SetReferer(Uri referer)
         {
             _referer = referer;
+        }
+
+        internal void SetIsLocalRequest(bool isLocalRequest)
+        {
+            _isLocalRequest = isLocalRequest;
         }
 
         /// <summary>
@@ -215,6 +221,11 @@ namespace Http.TestLibrary
         public override bool IsEntireEntityBodyIsPreloaded()
         {
             return true;
+        }
+
+        public override string GetRemoteAddress()
+        {
+            return _isLocalRequest ? "127.0.0.1" : "";
         }
     }
 }


### PR DESCRIPTION
* Allows to specify that the simulated request is local or remote via the fluent interface